### PR TITLE
Refactored the garden page

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -10,15 +10,25 @@ import {
   PlantPage,
   AddPlant,
   Garden,
-  PlantIdentifier
+  PlantIdentifier,
 } from "./pages";
 
-import { AuthProvider } from "./contexts";
+import { AuthProvider, GardenProvider } from "./contexts";
 import { Guest, User } from "./layouts";
 
 import { Popup } from "./components";
 
 import "./App.css";
+
+function GardenRoute() {
+  return (
+    <GardenProvider>
+      <Routes>
+        <Route path="/" element={<Garden />} />
+      </Routes>
+    </GardenProvider>
+  );
+}
 
 function App() {
   return (
@@ -30,13 +40,13 @@ function App() {
             <Route path="/login" element={<Login />} />
             <Route path="/register" element={<Register />} />
             <Route path="/addplant" element={<AddPlant />} />
-            <Route path="/garden" element={<Garden />} />
           </Route>
           <Route element={<User />}>
             <Route path="/dashboard" element={<Dashboard />} />
             <Route path="/plant-identifier" element={<PlantIdentifier />} />
             <Route path="/profile" element={<Profile />} />
             <Route path="/plants" element={<PlantPage />} />
+            <Route path="/garden/*" element={<GardenRoute />} />
             <Route path="*" element={<NotFound />} />
           </Route>
           <Route path="*" element={<Navigate to="/login" />} />

--- a/client/src/contexts/Garden/index.jsx
+++ b/client/src/contexts/Garden/index.jsx
@@ -1,0 +1,60 @@
+import { useState, useEffect, useContext, createContext } from "react";
+
+const GardenContext = createContext();
+
+export const GardenProvider = ({ children }) => {
+  const [display, setDisplay] = useState({});
+  const [plant, setPlant] = useState([]);
+  const [animal, setAnimal] = useState([]);
+
+  const token = localStorage.getItem("token");
+
+  useEffect(() => {
+    async function fetchDisplay() {
+      const apiURL = `${import.meta.env.VITE_SERVER}/displays`;
+      const headers = {
+        Authorization: token,
+      };
+
+      const response = await fetch(apiURL, { headers: headers });
+      const data = await response.json();
+      setDisplay(data);
+    }
+
+    async function fetchPlants() {
+      const apiURL = `${import.meta.env.VITE_SERVER}/plants`;
+      const headers = {
+        Authorization: token,
+      };
+
+      const response = await fetch(apiURL, { headers: headers });
+      const data = await response.json();
+      setPlant(data);
+    }
+
+    async function fetchAnimals() {
+      const apiURL = `${import.meta.env.VITE_SERVER}/animals`;
+      const headers = {
+        Authorization: token,
+      };
+
+      const response = await fetch(apiURL, { headers: headers });
+      const data = await response.json();
+      setAnimal(data);
+    }
+
+    fetchDisplay();
+    fetchPlants();
+    fetchAnimals();
+  }, []);
+
+  return (
+    <GardenContext.Provider
+      value={{display, setDisplay, plant, setPlant, animal, setAnimal}}
+    >
+      {children}
+    </GardenContext.Provider>
+  );
+};
+
+export const useGarden = () => useContext(GardenContext);

--- a/client/src/contexts/index.jsx
+++ b/client/src/contexts/index.jsx
@@ -1,1 +1,2 @@
 export { AuthProvider, useAuth } from "./Authentication";
+export { GardenProvider, useGarden } from "./Garden";

--- a/client/src/pages/Garden/index.jsx
+++ b/client/src/pages/Garden/index.jsx
@@ -1,51 +1,14 @@
 import React, { useState, useContext, useEffect } from "react";
 import style from "./style.module.css";
-import { useAuth } from "../../contexts";
+import { useAuth, useGarden } from "../../contexts";
 import CountdownTimer from "../../components/Timer";
 
 export default function Garden() {
-  const [display, setDisplay] = useState({});
-  const [plant, setPlant] = useState([]);
-  const [animal, setAnimal] = useState([]);
-
   const { user } = useAuth();
+  const { display, setDisplay, plant, setPlant, animal, setAnimal } =
+    useGarden();
+
   const token = localStorage.getItem("token");
-
-  async function fetchDisplay() {
-    const apiURL = `${import.meta.env.VITE_SERVER}/displays`;
-    const headers = {
-      Authorization: token,
-    };
-
-    const response = await fetch(apiURL, { headers: headers });
-    const data = await response.json();
-    setDisplay(data);
-    console.log("Display Data", data);
-  }
-
-  async function fetchPlants() {
-    const apiURL = `${import.meta.env.VITE_SERVER}/plants`;
-    const headers = {
-      Authorization: token,
-    };
-
-    const response = await fetch(apiURL, { headers: headers });
-    const data = await response.json();
-    setPlant(data);
-    console.log("Plant Data", data);
-  }
-
-  async function fetchAnimals() {
-    const apiURL = `${import.meta.env.VITE_SERVER}/animals`;
-    const headers = {
-      Authorization: token,
-    };
-
-    const response = await fetch(apiURL, { headers: headers });
-    const data = await response.json();
-    setAnimal(data);
-    console.log("Animal Data", data);
-  }
 
   async function waterPlant(plantObj) {
     try {
@@ -53,7 +16,7 @@ export default function Garden() {
       const new_water_satisfaction = 100;
       const updatedPlantObj = {
         ...plantObj,
-        soil_moisture : new_water_satisfaction,
+        soil_moisture: new_water_satisfaction,
       };
       const updatedPlants = plant.map((p) =>
         p.plant_id === updatedPlantObj.plant_id ? updatedPlantObj : p
@@ -94,7 +57,7 @@ export default function Garden() {
       const new_nutrient_satisfaction = 100;
       const updatedPlantObj = {
         ...plantObj,
-        soil_fertility : new_nutrient_satisfaction,
+        soil_fertility: new_nutrient_satisfaction,
       };
       const updatedPlants = plant.map((p) =>
         p.plant_id === updatedPlantObj.plant_id ? updatedPlantObj : p
@@ -110,7 +73,7 @@ export default function Garden() {
         "Content-Type": "application/json",
       };
       const body = JSON.stringify({
-        soil_fertility : new_nutrient_satisfaction,
+        soil_fertility: new_nutrient_satisfaction,
       });
 
       const response = await fetch(apiURL, {
@@ -128,12 +91,6 @@ export default function Garden() {
       console.error("Error while updating plant nutrient satisfaction:", error);
     }
   }
-
-  useEffect(() => {
-    fetchDisplay();
-    fetchPlants();
-    fetchAnimals();
-  }, []);
 
   return (
     <div className={style["outer-container"]}>

--- a/client/src/pages/Garden/index.jsx
+++ b/client/src/pages/Garden/index.jsx
@@ -7,17 +7,22 @@ export default function Garden() {
   const { user } = useAuth();
   const { display, setDisplay, plant, setPlant, animal, setAnimal } =
     useGarden();
-
   const token = localStorage.getItem("token");
 
-  async function waterPlant(plantObj) {
+  async function plantAction(plantObj, action) {
+    
+    //on button click will pass in 'water' or 'fertilise' as args
+
     try {
       //Update the state of the React App
-      const new_water_satisfaction = 100;
-      const updatedPlantObj = {
-        ...plantObj,
-        soil_moisture: new_water_satisfaction,
-      };
+      const satisfaction = 100;
+
+      // find out user is watering or fertilising the plant
+      const updatedPlantObj =
+        action === "water"
+          ? { ...plantObj, soil_moisture: satisfaction }
+          : { ...plantObj, soil_fertility: satisfaction };
+
       const updatedPlants = plant.map((p) =>
         p.plant_id === updatedPlantObj.plant_id ? updatedPlantObj : p
       );
@@ -31,9 +36,12 @@ export default function Garden() {
         Authorization: token,
         "Content-Type": "application/json",
       };
-      const body = JSON.stringify({
-        soil_moisture: new_water_satisfaction,
-      });
+
+      // find out user is watering or fertilising the plant
+      const body =
+        action === "water"
+          ? JSON.stringify({ soil_moisture: satisfaction })
+          : JSON.stringify({ soil_fertility: satisfaction });
 
       const response = await fetch(apiURL, {
         method: "PATCH",
@@ -42,53 +50,15 @@ export default function Garden() {
       });
 
       if (!response.ok) {
-        console.error("Failed to update plant water satisfaction");
+        console.error(`Failed to update plant ${action} satisfaction`);
         return;
       }
-      console.log("Plant water satisfaction updated successfully");
+      console.log(`Plant ${action} satisfaction updated successfully`);
     } catch (error) {
-      console.error("Error while updating plant water satisfaction:", error);
-    }
-  }
-
-  async function fertilisePlant(plantObj) {
-    try {
-      //Update the state of the React App
-      const new_nutrient_satisfaction = 100;
-      const updatedPlantObj = {
-        ...plantObj,
-        soil_fertility: new_nutrient_satisfaction,
-      };
-      const updatedPlants = plant.map((p) =>
-        p.plant_id === updatedPlantObj.plant_id ? updatedPlantObj : p
+      console.error(
+        `Error while updating plant ${action} satisfaction:`,
+        error
       );
-      setPlant(updatedPlants);
-
-      // Update the DB with a patch request
-      const apiURL = `${import.meta.env.VITE_SERVER}/plants/${
-        plantObj.plant_id
-      }`;
-      const headers = {
-        Authorization: token,
-        "Content-Type": "application/json",
-      };
-      const body = JSON.stringify({
-        soil_fertility: new_nutrient_satisfaction,
-      });
-
-      const response = await fetch(apiURL, {
-        method: "PATCH",
-        headers: headers,
-        body: body,
-      });
-
-      if (!response.ok) {
-        console.error("Failed to update plant nutrient satisfaction");
-        return;
-      }
-      console.log("Plant nutrient satisfaction updated successfully");
-    } catch (error) {
-      console.error("Error while updating plant nutrient satisfaction:", error);
     }
   }
 
@@ -119,9 +89,11 @@ export default function Garden() {
                     {key}: {value}
                   </p>
                 ))}
-                <button onClick={() => waterPlant(plantObj)}>Water</button>
+                <button onClick={() => plantAction(plantObj, 'water')}>
+                  Water
+                </button>
                 &nbsp;&nbsp;
-                <button onClick={() => fertilisePlant(plantObj)}>
+                <button onClick={() => plantAction(plantObj, 'fertilise')}>
                   Fertilise
                 </button>
               </div>


### PR DESCRIPTION
- Add context to Garden Page with the function `useGarden()`. These variable `display, setDisplay, plant, setPlant, animal, setAnimal`  are accessible under the Garden Route.
- Refactored the action buttons in API. Water and Fertilise now share the same function to update the React state and the backend.
- Added context `GardenProvider`. On load, the context will fetch from DB the user's display, plant and animal data.
- Modified `client/src/App.jsx` to wrap only the Garden Route inside Garden Provider. This is to avoid triggering Garden Provider  before user logins in. Without a token in localstorage, Garden Provider would fail to fetch from DB.